### PR TITLE
Add section & links for Avalanche (AVAX)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,14 +2,15 @@
 
 > A curated list of crypto project trackers and analytics dashboards.
 
-
 ## Contents
+
 - [0x](#0x)
 - [1inch](#1inch)
 - [Aave](#aave)
 - [Aragon](#aragon)
 - [Arweave](#arweave)
 - [Augur](#augur)
+- [Avalanche](#avalanche)
 - [Axie Infinity](#axie-infinity)
 - [Balancer](#balancer)
 - [Bancor](#bancor)
@@ -98,8 +99,8 @@
 - [yearn](#yearn)
 - [Other](#other)
 
-
 ## 0x
+
 - https://0xtracker.com
 - https://twitter.com/0xtracker
 - https://yield.fi/app/0x
@@ -111,9 +112,11 @@
 - https://duneanalytics.com/0x/matcha
 
 ## 1inch
+
 - https://duneanalytics.com/k06a/1inch-exchange
 
 ## Aave
+
 - https://aavescan.com
 - https://aavewatch.now.sh
 - https://aave-futuristic-dashboard.now.sh
@@ -125,13 +128,16 @@
 - https://www.theblockcrypto.com/data/open-finance/cryptocurrency-lending
 
 ## Aragon
+
 - https://scout.cool/aragon/mainnet
 - https://apiary.1hive.org
 
 ## Arweave
+
 - https://viewblock.io/arweave
 
 ## Augur
+
 - https://predictionexplorer.com
 - https://predictions.global
 - https://blacktemplar.github.io/augur-market-odds
@@ -143,7 +149,20 @@
 - https://public.tableau.com/profile/alethio.defi#!/vizhome/Augur/AugurPopularTags
 - https://defipulse.com/augur
 
+## Avalanche
+
+- https://explorer.avax.network/
+- https://avascan.info/
+- https://avax.dev/
+- https://burnedavax.com/
+- https://avaxmap.com/
+- https://info.pangolin.exchange/
+- https://www.avax-projects.com/
+- https://www.avalanchelounge.com/
+- https://info.yetiswap.xyz
+
 ## Axie Infinity
+
 - https://marketplace.axieinfinity.com/dashboard
 - https://nonfungible.com/market/history/axieinfinity
 - https://bonifaty.github.io/axie-bounty
@@ -153,6 +172,7 @@
 - https://www.dapp.com/dapp/Axie-Infinity
 
 ## Balancer
+
 - https://pools.balancer.exchange/#/list
 - http://www.predictions.exchange/balancer/None
 - http://pools.vision
@@ -163,17 +183,20 @@
 - https://defipulse.com/balancer
 
 ## Bancor
+
 - https://defipulse.com/bancor
 - https://defimarketcap.io/protocol/bancor
 - https://duneanalytics.com/bancor
 - https://zumzoom.github.io/analytics/bancor/roi
 
 ## Basic Attention Token
+
 - https://batgrowth.com
 - https://bravebat.info
 - https://brave.com/transparency
 
 ## Bitcoin
+
 - https://bitcoinvisuals.com
 - https://jochen-hoenicke.de/queue/#0,24h
 - https://statoshi.info
@@ -194,6 +217,7 @@
 - https://www.theblockcrypto.com/data/on-chain-metrics/bitcoin
 
 ## Bitcoin on Ethereum
+
 - https://btconethereum.com
 - http://www.predictions.exchange/ethbtc
 - https://duneanalytics.com/eliasimos/btc-on-ethereum_1
@@ -204,13 +228,16 @@
 - https://www.theblockcrypto.com/data/open-finance/asset-management
 
 ## bloXroute
+
 - https://www.bdn-explorer.com
 
 ## bZx
+
 - https://defipulse.com/bzx
 - https://defimarketcap.io/protocol/fulcrum
 
 ## Celo
+
 - https://www.thecelo.com
 - https://celo.org/validators/explore
 - https://explorer.celo.org
@@ -219,12 +246,15 @@
 - http://celoreserve.org
 
 ## Chainlink
+
 - https://feeds.chain.link
 
 ## Chia
+
 - https://www.chiaexplorer.com
 
 ## Compound
+
 - https://app.compound.finance/#Markets
 - https://loanscan.io/compound
 - https://defipulse.com/compound
@@ -241,6 +271,7 @@
 - https://www.theblockcrypto.com/data/open-finance/cryptocurrency-lending
 
 ## Cosmos
+
 - https://mintscan.io
 - https://cosmoscan.net
 - https://cosmos.bigdipper.live
@@ -254,9 +285,11 @@
 - https://www.cosmosoutpost.io/cosmos/network?lang=en
 
 ## Cream
+
 - https://defipulse.com/c.r.e.a.m.-finance
 
 ## Crypto Art
+
 - https://cryptoart.io
 - https://cryptoartpulse.com
 - https://superrare.co/market
@@ -265,17 +298,21 @@
 - https://duneanalytics.com/rchen8/superrare_4
 
 ## Cryptokitties
+
 - https://kittysales.herokuapp.com
 
 ## Curve
+
 - https://duneanalytics.com/pengiundev/curve-fi-users
 - https://defipulse.com/curve-finance
 
 ## DAOs
+
 - http://deepdao.world/#/app/dashboard
 - https://daometrics.com
 
 ## Dapps
+
 - https://dappradar.com
 - https://dapp.review
 - https://stateofthedapps.com
@@ -284,6 +321,7 @@
 - https://www.dapp.com/ranking
 
 ## Decentralized Exchanges
+
 - https://duneanalytics.com/hagaetc/dex-metrics
 - https://dex.watch
 - https://etherscan.io/dextracker
@@ -298,6 +336,7 @@
 - https://www.theblockcrypto.com/data/open-finance/dex-non-custodial
 
 ## Decentralized Finance
+
 - https://defipulse.com
 - https://duneanalytics.com/rchen8/defi-users-over-time
 - https://dai-in-defi.com
@@ -311,36 +350,45 @@
 - https://defi.ethereumwisdom.com
 
 ## DeversiFi
+
 - https://defipulse.com/deversifi
 
 ## dForce
+
 - https://defipulse.com/dforce
 
 ## DODO
+
 - https://defipulse.com/dodo
 
 ## dYdX
+
 - https://bloxy.info/list_margin_positions
 - https://scout.cool/dydxprotocol/mainnet
 - https://duneanalytics.com/tomhschmidt/dydx_4
 - https://defipulse.com/dydx
 
 ## Edgeware
+
 - https://telemetry.polkadot.io/#list/Edgeware
 
 ## Empty Set Dollar
+
 - https://esd.tools
 - https://www.duneanalytics.com/itzler/empty-set-dollar
 
 ## ENS
+
 - https://duneanalytics.com/makoto/ens
 
 ## Erasure
+
 - https://duneanalytics.com/rchen8/erasure_2
 - https://defipulse.com/erasure
 - https://twitter.com/ErasureStaked
 
 ## Ethereum
+
 - https://ethstats.net
 - https://ethstats.io
 - https://ethernodes.org
@@ -359,65 +407,81 @@
 - https://www.duneanalytics.com/hagaetc/eth2-0-deposits
 
 ## Ethereum Classic
+
 - https://dappdirect.net
 
 ## Exchanges
+
 - https://skew.com/dashboard/bitcoin-futures
 - https://www.tokenanalyst.io
 - https://cer.live
 - https://www.bitcointradevolume.com
 
 ## Filecoin
+
 - https://filstats.com
 
 ## Flexa
+
 - https://defipulse.com/flexa
 
 ## FOAM
+
 - https://foam.tools
 
 ## Foundation
+
 - https://fnd.info
 
 ## Gnosis
+
 - https://duneanalytics.com/c3rnst/gnosis-dex-protocol
 - https://defipulse.com/gnosis
 
 ## Grin
+
 - https://grinscan.net/charts
 - https://grin.blockscan.com
 
 ## Handshake
+
 - https://6block.com/en
 - https://hsd.tools/leaderboard
 - https://hnscan.com
 - https://hnspool.com/statistics
 
 ## Harvest Finance
+
 - https://farmdashboard.xyz
 - https://defipulse.com/harvest-finance
 
 ## Hegic
+
 - https://defipulse.com/hegic
 - https://defillama.com/protocol/hegic
 - https://duneanalytics.com/slash125/hegic-v2
 
 ## Helium
+
 - https://dashboard.helium.com
 - https://explorer.helium.com
 - https://helium.plus
 - https://www.sitebot.com/helium/summary
 
 ## InstaDApp
+
 - https://defipulse.com/instadapp
 
 ## KeeperDAO
+
 - https://duneanalytics.com/eliasimos/keeper-dao-eliasimos-
 
 ## Kleros
+
 - http://kleroscan.com
 
 ## Kyber
+
 - https://tracker.kyber.network
 - https://defipulse.com/kyber
 - https://twitter.com/KyberTracker
@@ -426,6 +490,7 @@
 - https://duneanalytics.com/ha.hoang/kyber-network_2
 
 ## Lightning Network
+
 - https://1ml.com
 - https://bitcoinvisuals.com/lightning
 - https://lightblock.me
@@ -435,10 +500,12 @@
 - https://www.lapps.co/all-time
 
 ## Livepeer
+
 - https://scout.cool/livepeer/mainnet
 - https://explorer.livepeer.org
 
 ## Loans
+
 - https://duneanalytics.com/hagaetc/lending
 - https://loanscan.io
 - https://loans.descipher.io
@@ -447,10 +514,12 @@
 - https://defiprime.com/defi-rates
 
 ## Loopring
+
 - https://duneanalytics.com/Brecht/loopring
 - https://defipulse.com/loopring
 
 ## MakerDAO
+
 - https://mkr.tools
 - https://defiexplore.com
 - https://daistats.com
@@ -473,60 +542,75 @@
 - https://www.theblockcrypto.com/data/open-finance/stablecoins
 
 ## MCDEX
+
 - https://defipulse.com/mcdex
 
 ## Melon
+
 - https://monitoring.melon.network
 - https://defipulse.com/melon
 
 ## mStable
+
 - https://app.mstable.org/analytics
 - https://defipulse.com/mstable
 
 ## Nervos
+
 - https://explorer.nervos.org
 
 ## Nexus Mutual
+
 - https://nexustracker.io
 - https://defipulse.com/nexus-mutual
 - https://twitter.com/NexusMutualBot
 
 ## NFTs
+
 - https://nonfungible.com
 - https://opensea.io/rankings
 - https://cryptoslam.io
 
 ## Notional
+
 - https://duneanalytics.com/notional/notional-market-summary-by-currency
 - https://duneanalytics.com/rchen8/notional
 - https://defipulse.com/notional
 
 ## Oasis
+
 - https://www.oasisscan.com
 
 ## OpenSea
+
 - https://duneanalytics.com/rchen8/opensea
 - https://dappradar.com/app/15/opensea
 
 ## Opyn
+
 - https://explore.duneanalytics.com/queries/3540#6842
 - https://duneanalytics.com/tomhschmidt/opyn_1
 - https://antoncoding.github.io/opyn-liquidator
 - https://defipulse.com/opyn
 
 ## Paraswap
+
 - https://duneanalytics.com/mounir/paraswap
 
 ## Perpetual Protocol
+
 - https://duneanalytics.com/yenwen/perpetual-protocol_2
 
 ## Plasma
+
 - https://mainnet.leapdao.org/explorer
 
 ## Pocket Network
+
 - https://c0d3r.org/NetworkCharts
 
 ## Polkadot
+
 - https://telemetry.polkadot.io
 - https://polkascan.io
 - https://polkastats.io
@@ -534,22 +618,27 @@
 - https://polkadot.js.org/apps/#/explorer
 
 ## Polymarket
+
 - http://polymarketwhales.info
 
 ## PoolTogether
+
 - https://www.pooltogether.com/#stats
 - https://defimarketcap.io/protocol/pool-together
 - https://twitter.com/PoolTogetherBot
 
 ## RAY
+
 - https://defipulse.com/robo-advisor-for-yield
-- https://staking.staked.us/ray 
+- https://staking.staked.us/ray
 - https://twitter.com/RoboForYield
 
 ## Reddit
+
 - https://reddit.dappradar.com
 
 ## Set Protocol
+
 - https://scout.cool/setprotocol/mainnet
 - https://scout.cool/setprotocol/mainnet/dashboards/5d25f57c5b19c00017eebbe3
 - https://public.tableau.com/profile/alethio.defi#!/vizhome/TokenSets/TokenSets
@@ -558,16 +647,20 @@
 - https://tokenviz.io
 
 ## Sia
+
 - https://siastats.info
 
 ## Social
+
 - https://fifty.one
 - https://hive.one
 
 ## Sorare
+
 - https://www.soraredata.com
 
 ## Stablecoins
+
 - https://duneanalytics.com/hagaetc/stablecoins
 - https://stablecoinindex.com
 - https://stablecoinstats.com
@@ -582,11 +675,13 @@
 - https://skew.com/dashboard/stable-coins
 
 ## Sushiswap
+
 - https://sushi.zippo.io
 - https://sushiswap.vision/home
 - https://defipulse.com/sushiswap
 
 ## Synthetix
+
 - https://dashboard.synthetix.io
 - http://synthetixstats.com
 - https://defipulse.com/synthetix
@@ -598,10 +693,12 @@
 - https://snx.tools/home
 
 ## Terra
+
 - https://station.terra.money
 - https://www.chaiscan.com
 
 ## Tezos
+
 - https://www.mytezosbaker.com
 - https://dunscan.io
 - https://tezos.id
@@ -609,9 +706,11 @@
 - https://twitter.com/tezosagorabot
 
 ## Tornado Cash
+
 - https://duneanalytics.com/poma/tornado-cash_1
 
 ## Uniswap
+
 - https://uniswap.info
 - https://zumzoom.github.io/analytics/uniswap
 - https://www.uniswaproi.com
@@ -626,13 +725,16 @@
 - http://www.predictions.exchange/uniswap_markets
 
 ## Urbit
+
 - https://opensea.io/assets/urbit-id
 - https://urbit.live/stats
 
 ## Volmex Finance
+
 - https://volmex.finance/indices/eth
 
 ## Wallets
+
 - https://duneanalytics.com/kingjacob/wallets
 - https://duneanalytics.com/tschubotz/gnosis-multisig_1
 - https://duneanalytics.com/tschubotz/gnosis-safe_2
@@ -642,11 +744,13 @@
 - https://duneanalytics.com/tschubotz/monolith
 
 ## xDai
+
 - https://blockscout.com/poa/dai
 - https://dai-netstat.poa.network
 - https://defipulse.com/xdai
 
 ## yearn
+
 - https://feel-the-yearn.app/vaults
 - https://stats.finance/yearn
 - https://defipulse.com/yearn.finance
@@ -654,19 +758,24 @@
 - https://duneanalytics.com/milkyklim/yearn-governance-yfi-
 
 ## Other
+
 ### 51% attacks
+
 - https://crypto51.app
 - https://howmanyconfs.com
 
 ### Boards
+
 - https://boards.messari.io
 
 ### Coin correlations
+
 - https://www.tokenanalyst.io/compare
 - https://coinmetrics.io/correlation-charts
 - https://cointracker.io/visualizations/coin_correlations
 
 ### Gas
+
 - https://ethgasstation.info
 - https://www.gasnow.org
 - https://www.etherchain.org/api/gasPriceOracle
@@ -682,30 +791,34 @@
 - https://github.com/unspentio/ethereum-gas-prices-browser-extension
 
 ### Mining profitability
+
 - https://whattomine.com
 
 ### Oracles
+
 - https://oracles.club
 - https://github.com/linda-xie/defi-oracles
 
 ### Price
+
 - https://coinmarketcap.com
 - https://messari.io/screener
 - https://coin360.com
 - https://www.coingecko.com
 
 ### Security Audits
+
 - https://consensys.github.io/blockchainSecurityDB
 - http://defisafety.com
 
 ### Staking
+
 - https://stakingrewards.com
 - https://staked.us/yields
 
 ## Contribute
 
 Contributions welcome! Read the [contribution guidelines](contributing.md) first.
-
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,6 @@
 - https://info.pangolin.exchange/
 - https://www.avax-projects.com/
 - https://www.avalanchelounge.com/
-- https://info.yetiswap.xyz
 
 ## Axie Infinity
 


### PR DESCRIPTION
I've assembled a list of useful pages/trackers for Avalanche that cover various metrics [https://github.com/ava-labs/avalanchego](url)

Project Homepage:
Ava-Labs: [https://www.avalabs.org/](url)