### PR TITLE
Add DexScreener to Decentralized Exchanges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -289,6 +289,7 @@
 - https://www.dapp.com/ranking
 
 ## Decentralized Exchanges
+- https://dexscreener.com
 - https://dex.watch
 - https://etherscan.io/dextracker
 - https://dexindex.io


### PR DESCRIPTION
Adds https://dexscreener.com under the Decentralized Exchanges section as a widely used tracker for token pairs and DEX market data.