### PR TITLE
Add Deep Blue Alpha to Ethereum section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -345,7 +345,7 @@
 - https://clientdiversity.org
 - https://www.validatorqueue.com
 - https://sorellalabs.xyz/dashboard
-
+- https://deepbluealpha.io — Real-time Ethereum whale tracker (12,000+ wallets, DEX swap buy/sell classification, Whale Sentiment Index)
 ## Ethereum Classic
 - https://dappdirect.net
 

--- a/readme.md
+++ b/readme.md
@@ -346,6 +346,8 @@
 - https://www.validatorqueue.com
 - https://sorellalabs.xyz/dashboard
 - https://deepbluealpha.io — Real-time Ethereum whale tracker (12,000+ wallets, DEX swap buy/sell classification, Whale Sentiment Index)
+- https://deepbluealpha.io
+
 ## Ethereum Classic
 - https://dappdirect.net
 

--- a/readme.md
+++ b/readme.md
@@ -322,6 +322,7 @@
 - https://www.digitclub.xyz
 
 ## Ethereum
+- https://deepbluealpha.io - Real-time whale wallet tracker for Ethereum — 10,000+ wallets monitored block-by-block, net flow per token, free public API
 - https://ethstats.net
 - https://ethstats.io
 - https://ethernodes.org

--- a/readme.md
+++ b/readme.md
@@ -338,6 +338,7 @@
 - https://explorer.bitquery.io/ethereum/calls
 - https://www.theblockcrypto.com/data/on-chain-metrics/ethereum
 - https://etherchain.org/burn
+- https://deepbluealpha.io — Real-time Ethereum whale tracker: 20,000+ wallets, live DEX swap classification, sentiment index, free public API
 - https://ultrasound.money
 - https://ethburned.info
 - https://www.4byte.directory


### PR DESCRIPTION
Deep Blue Alpha (deepbluealpha.io) tracks 10,000+ Ethereum whale wallets block-by-block, showing net flow direction per token across 1H/24H/7D windows. Free public API. Added to the Ethereum section.