### PR TITLE
Add btcdash.org to Bitcoin section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,7 @@
 - http://bitcoin.sipa.be
 - https://bitcoin.clarkmoody.com/dashboard
 - https://www.theblockcrypto.com/data/on-chain-metrics/bitcoin
+- https://btcdash.org
 
 ## Bitcoin on Ethereum
 - https://btconethereum.com


### PR DESCRIPTION
Adds BTCDash (btcdash.org) to the Bitcoin section - a free, real-time Bitcoin dashboard and analytics tracker: price with long-term moving averages, halving countdown, hashrate & difficulty, fee market, Fear & Greed, on-chain valuation (MVRV, realized price) and Lightning stats. Client-side only, no signup, no ads. Similar in spirit to bitcoin.clarkmoody.com/dashboard already on the list.